### PR TITLE
docs: add missing flag for gitignore download

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and anything related to Typescript-based Infrastructure as Code.
 
 you can download it to a project/repository:
 ```bash
-curl -O https://github.com/bettermarks/.github/raw/main/.gitignore
+curl -LO https://github.com/bettermarks/.github/raw/main/.gitignore
 ```
 
 It can also be used as a default for the current user on your (bettermarks) machine, run:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ so they **need to be copied manually** to use them.
 
 ### .gitignore
 
-Provides common ignore patters for user specific files like secrets, notes, editor configs, 
+Provides common ignore patterns for user specific files like secrets, notes, editor configs, 
 and anything related to Typescript-based Infrastructure as Code.
 
 you can download it to a project/repository:


### PR DESCRIPTION
to follow the redirects provided by GitHub

Just tested the script by actually copy pasting it and discovered that it is not working as expected.
Now it does