### PR TITLE
fix: Reduce and improve the PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,9 @@
-# Description
+<!-- Source https://github.com/bettermarks/.github#PULL_REQUEST_TEMPLATE.md -->
+REPLACE the above comment and this text, to allow any future reader,
+to understand WHY you are making this change now.
 
-Short summary of the change.
+Can you imagine this change breaks anything when it lands or reaches users?
+Either REPLACE this section with what you did/tested/checked/assumed to mitigate the risk.
+Or DROP this section if you don't see any risk.
 
-Relates to https://bettermarks.atlassian.net/browse/BM-
-
-## Type of change
-
-- [ ] Bug fix
-- [ ] New feature 
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
-# How Has This Been Tested?
-
-Please describe the tests that you ran to verify your changes
-
-- Test A
-- Test B
+https://bettermarks.atlassian.net/browse/BM-

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,9 @@
 REPLACE the above comment and this text, to allow any future reader,
 to understand WHY you are making this change now.
 
-Can you imagine this change breaks anything when it lands or reaches users?
-Either REPLACE this section with what you did/tested/checked/assumed to mitigate the risk.
-Or DROP this section if you don't see any risk.
+<!-- How has this been tested? -->
+
+REPLACE this section with how you tested the mitigate risks related to these changes
+or DROP this section if you don't see any risk.
 
 https://bettermarks.atlassian.net/browse/BM-


### PR DESCRIPTION
Since we are using conventional commit messages including for PR titles, the "type of change" section is redundant.

In many pull requests the template was never updated/used and irrelevant sections were not dropped.

- By clearly describing what to write it hopefully has the same effect of helping people to tink about it.
- By using the words **REPLACE** and **DROP** in each section, the hope is that people will follow the instructions more often. Since the text doesn't make any sense as part of a real PR description.
- It would be possible to add an automated check that requires people to at least drop this text before a PR can land.

By adding a link to the file this template comes from, more people can be aware without anybody telling them, so they are encouraged to contribute.
