### PR TITLE
feat: add git-hooks/no-commit-to-default-branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: local
+    hooks:
+    - id: no-commit-to-default-branch
+      name: No commit to default branch
+      entry: git-hooks/no-commit-to-default-branch
+      args:
+        [main]
+      always_run: true
+      language: script
+      pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,16 @@
+# this file makes it possible to use this repository as a "repo" in a .pre-commit-config.yaml
+# see https://pre-commit.com/#creating-new-hooks
+
+# prevents commits to the main/master/default branch
+# the branch has to be passed as the first argument!
 - id: no-commit-to-default-branch
   name: No commit to default branch
   entry: git-hooks/no-commit-to-default-branch
   always_run: true
   language: script
   pass_filenames: false
+# updates versions and SHAs in a .pre-commit-config.yaml
+# see https://pre-commit.com/#pre-commit-autoupdate
 - id: pre-commit-autoupdate
   name: pre-commit autoupdate
   entry: pre-commit autoupdate

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: no-commit-to-default-branch
+  name: No commit to default branch
+  entry: git-hooks/no-commit-to-default-branch
+  always_run: true
+  language: script
+  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,9 @@
   always_run: true
   language: script
   pass_filenames: false
+- id: pre-commit-autoupdate
+  name: pre-commit autoupdate
+  entry: pre-commit autoupdate
+  language: system
+  always_run: true
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -61,23 +61,22 @@ There are two widely used options for pre-commit hooks configured inside a repos
 - <https://pre-commit.com> (language agnostic)
 - <https://typicode.github.io/husky/> (most streamlined npm/pnpm/yarn integration)
 
-Since some repositories use `pre-commit`, configure the following after installing the tool:
+Since some repositories use `pre-commit`, configure the following after installing it
+using your package manager of choice or by following [the docs](https://pre-commit.com/#install):
 
 ```bash
 gh repo clone bettermarks/.github
 git config --global init.templateDir $(pwd)/.github/git-hooks/init-template
 ```
 
-
-#### with pre-commit
+#### in repos using pre-commit
 
 `pre-commit` is a "language agnostic" tool which hides away the complexity of installing the required tools globally,
-but the integraiton i not ideal for npm base projects.
+but the integration is not ideal for npm/pnpm/yarn based projects.
 
-1. Install `pre-commit` to your system using your package manager of choice or by following [the docs](https://pre-commit.com/#install).
-2. To enable the configured git hooks run `pre-commit install`
-3. Make sure that the docs in the repository provide a hint that you should do step 2 when cloning the repository!
-4. add the following under the `repos` key in the `.pre-commit-config.yaml`:
+1. To enable the configured git hooks for a repository run `pre-commit install`
+2. Make sure that the docs in the repository provide a hint that you should do step 2 when cloning the repository!
+3. add the following under the `repos` key in the `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/bettermarks/.github
@@ -90,7 +89,7 @@ repos:
       - id: pre-commit-autoupdate
 ```
 
-#### with husky
+#### in repos using husky
 
 if the repository is a top level npm/pnpm/yarn project, you most likely prefer to use (husky)[https://typicode.github.io/husky/].
 
@@ -99,7 +98,9 @@ which needs ot be added to the version control system.
 
 Download a copy of the hook you would like to add to the `.husky` directory
 ```bash
-(cd .husky && curl -LO https://github.com/bettermarks/.github/raw/main/git-hooks/no-commit-to-default-branch)
+(cd .husky && \
+ curl -LO https://github.com/bettermarks/.github/raw/main/git-hooks/no-commit-to-default-branch && \
+ chmod +x no-commit-to-default-branch)
 ```
 and invoke it from your pre-commit hook, by passing the default branch name as the first argument
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,5 +50,45 @@ It can also be used as a default for the current user on your (bettermarks) mach
 ```bash
 cd ~
 gh repo clone bettermarks/.github
-git config --global core.excludesfile ~/.github/.gitignore
+git config --global core.excludesfile $(pwd)/.gitignore
+```
+
+### git-hooks
+
+Provides common pre-commit hooks that can be reused in other repositories without a lot of config.
+
+You have to deice for one of the below options, since they both the same mechanism,
+so they would override each other.
+
+#### with pre-commit
+
+`pre-commit` is a "language agnostic" tool which hides away the complexity of installing the required tools globally,
+but the integraiton i not ideal for npm base projects.
+
+1. Install `pre-commit` to your system using your package manager of choice or by following [the docs](https://pre-commit.com/#install).
+2. To enable the configured git hooks run `pre-commit install`
+3. Make sure that the docs in the repository provide a hint that you should do step 2 when cloning the repository!
+4. add the following under the `repos` key in the `.pre-commit-config.yaml`:
+```yaml
+  - repo: https://github.com/bettermarks/.github
+    hooks:
+      - id: no-commit-to-default-branch
+        args: 
+          - main # or master or whatever it your default branch
+```
+
+#### with husky
+
+if the repository is a top level npm/pnpm/yarn project, you most likely prefer to use (husky)[https://typicode.github.io/husky/].
+
+After configuring husky including the `prepare` script, there will be a `.husky` directory,
+which needs ot be added to the version control system.
+
+Download a copy of the hook you would like to add to the `.husky` directory
+```bash
+(cd .husky && curl -LO https://github.com/bettermarks/.github/raw/main/git-hooks/no-commit-to-default-branch)
+```
+and invoke it from your pre-commit hook, by passing the default branch name as the first argument
+```bash
+echo ".husky/no-commit-to-default-branch main" >> .husky/pre-commit
 ```

--- a/README.md
+++ b/README.md
@@ -50,15 +50,24 @@ It can also be used as a default for the current user on your (bettermarks) mach
 ```bash
 cd ~
 gh repo clone bettermarks/.github
-git config --global core.excludesfile $(pwd)/.gitignore
+git config --global core.excludesfile $(pwd)/.github/.gitignore
 ```
 
 ### git-hooks
 
 Provides common pre-commit hooks that can be reused in other repositories without a lot of config.
 
-You have to deice for one of the below options, since they both the same mechanism,
-so they would override each other.
+There are two widely used options for pre-commit hooks configured inside a repository:
+- <https://pre-commit.com> (language agnostic)
+- <https://typicode.github.io/husky/> (most streamlined npm/pnpm/yarn integration)
+
+Since some repositories use `pre-commit`, configure the following after installing the tool:
+
+```bash
+gh repo clone bettermarks/.github
+git config --global init.templateDir $(pwd)/.github/git-hooks/init-template
+```
+
 
 #### with pre-commit
 

--- a/README.md
+++ b/README.md
@@ -61,15 +61,22 @@ There are two widely used options for pre-commit hooks configured inside a repos
 - <https://pre-commit.com> (language agnostic)
 - <https://typicode.github.io/husky/> (most streamlined npm/pnpm/yarn integration)
 
-Since some repositories use `pre-commit`, configure the following after installing it
-using your package manager of choice or by following [the docs](https://pre-commit.com/#install):
-
+Since some repositories use `pre-commit`, 
+to not forget to run `pre-commit install` after cloning repository:
+1. install `pre-commit`
+using your package manager of choice or by following [the docs](https://pre-commit.com/#install)
+2. configure global (user level) init template for git 
 ```bash
 gh repo clone bettermarks/.github
 git config --global init.templateDir $(pwd)/.github/git-hooks/init-template
 ```
+3. in the directory containing the repositories you already cloned,
+   activate pre-commit in every repository containing a `.pre-commit-config.yaml`:
+```bash
+find . -maxdepth 1 -name .pre-commit-config.yaml -type f -execdir pwd \; -execdir pre-commit install \;
+```
 
-#### in repos using pre-commit
+#### add a hook to a repo using pre-commit
 
 `pre-commit` is a "language agnostic" tool which hides away the complexity of installing the required tools globally,
 but the integration is not ideal for npm/pnpm/yarn based projects.
@@ -89,7 +96,7 @@ repos:
       - id: pre-commit-autoupdate
 ```
 
-#### in repos using husky
+#### add hook to a repo using husky
 
 if the repository is a top level npm/pnpm/yarn project, you most likely prefer to use (husky)[https://typicode.github.io/husky/].
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It can also be used as a default for the current user on your (bettermarks) mach
 ```bash
 cd ~
 gh repo clone bettermarks/.github
-git config --global core.excludesfile $(pwd)/.github/.gitignore
+git config --global core.excludesfile $PWD/.github/.gitignore
 ```
 
 ### git-hooks
@@ -68,7 +68,7 @@ using your package manager of choice or by following [the docs](https://pre-comm
 2. configure global (user level) init template for git 
 ```bash
 gh repo clone bettermarks/.github
-git config --global init.templateDir $(pwd)/.github/git-hooks/init-template
+git config --global init.templateDir $PWD/.github/git-hooks/init-template
 ```
 3. in the directory containing the repositories you already cloned,
    activate pre-commit in every repository containing a `.pre-commit-config.yaml`:

--- a/README.md
+++ b/README.md
@@ -70,11 +70,15 @@ but the integraiton i not ideal for npm base projects.
 3. Make sure that the docs in the repository provide a hint that you should do step 2 when cloning the repository!
 4. add the following under the `repos` key in the `.pre-commit-config.yaml`:
 ```yaml
+repos:
   - repo: https://github.com/bettermarks/.github
+    # to get the latest SHA use `gh api /repos/bettermarks/.github/commits/HEAD -q .sha`
+    rev: SHA 
     hooks:
       - id: no-commit-to-default-branch
-        args: 
-          - main # or master or whatever it your default branch
+        # the default branch of the repository containing this yaml file)
+        args: [main]
+      - id: pre-commit-autoupdate
 ```
 
 #### with husky

--- a/git-hooks/init-template/hooks/pre-commit
+++ b/git-hooks/init-template/hooks/pre-commit
@@ -15,7 +15,7 @@ if [ -f .pre-commit-config.yaml ]; then
       echo "To install the pre-commit tool, use your package manager or follow these instructions:" 1>&2
       echo "  https://pre-commit.com/#installation" 1>&2
     fi
-    echo 'Jo, this repository contains a pre-commit configuration, to enable it run' 1>&2
+    echo 'Yo, this repository contains a pre-commit configuration, to enable it run' 1>&2
     echo '  pre-commit install' 1>&2
     exit 1
 fi

--- a/git-hooks/init-template/hooks/pre-commit
+++ b/git-hooks/init-template/hooks/pre-commit
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
-# source https://github.com/bettermarks/.github/git-hooks/
-echo "executing $0 in $(pwd)"
+# source https://github.com/bettermarks/.github#git-hooks
+echo "executing $0 in $(pwd)" 1>&2
 set -eu
 # see https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories
 # instructions to enable it are in the top level README
+# to disable ALL hooks for a single commit use
+#   git commit --no-verify ...
+# to disable this hook for the current repository permanently, run
+#   rm .git/hooks/pre-commit
+# to disable adding this hook after cloning a repo, run
+#   git config --global --unset init.templatePath
 if [ -f .pre-commit-config.yaml ]; then
-    echo 'pre-commit configuration detected, but `pre-commit install` was never run' 1>&2
+    if ! command -v pre-commit >/dev/null 2>/dev/null; then
+      echo "To install the pre-commit tool, use your package manager or follow these instructions:" 1>&2
+      echo "  https://pre-commit.com/#installation" 1>&2
+    fi
+    echo 'Jo, this repository contains a pre-commit configuration, to enable it run' 1>&2
+    echo '  pre-commit install' 1>&2
     exit 1
 fi

--- a/git-hooks/init-template/hooks/pre-commit
+++ b/git-hooks/init-template/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # source https://github.com/bettermarks/.github#git-hooks
-echo "executing $0 in $(pwd)" 1>&2
+echo "executing $0 in $PWD" 1>&2
 set -eu
 # see https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories
 # instructions to enable it are in the top level README

--- a/git-hooks/init-template/hooks/pre-commit
+++ b/git-hooks/init-template/hooks/pre-commit
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
+# source https://github.com/bettermarks/.github/git-hooks/
+echo "executing $0 in $(pwd)"
 set -eu
 # see https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories
+# instructions to enable it are in the top level README
 if [ -f .pre-commit-config.yaml ]; then
     echo 'pre-commit configuration detected, but `pre-commit install` was never run' 1>&2
     exit 1

--- a/git-hooks/init-template/hooks/pre-commit
+++ b/git-hooks/init-template/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+# see https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories
+if [ -f .pre-commit-config.yaml ]; then
+    echo 'pre-commit configuration detected, but `pre-commit install` was never run' 1>&2
+    exit 1
+fi

--- a/git-hooks/init.sh
+++ b/git-hooks/init.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# source https://github.com/bettermarks/.github#git-hooks
+# why https://typicode.github.io/husky/how-to.html#solution
+# to use it place a copy like this:
+#   mkdir -p ~/.config/husky && cp git-hooks/init.sh ~/.config/husky
+
+# "enable" direnv
+if [ -s .envrc ]; then
+  echo "enabling direnv"
+
+  eval $(direnv export bash)
+fi
+
+# enable nvm (tweak it when
+if [ -s .nvmrc ]; then
+  echo "enabling nvm"
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+  node --version
+  # make pnpm/yarn available
+  corepack enable
+fi

--- a/git-hooks/no-commit-to-default-branch
+++ b/git-hooks/no-commit-to-default-branch
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+# source https://github.com/bettermarks/.github/git-hooks/
+echo "executing $0 in $(pwd)"
+set -eu
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# needs to be passed as the first argument, should be "main" or "master" in most cases
+default_branch=$1
+
+if [ ! -f ".git/refs/heads/$1" ]; then
+  echo "There is no local branch with the name '$1', so it can not be the default branch."
+  exit 2
+fi
+
+if [ "$current_branch" = "$default_branch" ]; then
+  echo "Do not use the default branch '$default_branch' directly, create a feature branch!"
+  exit 1
+fi

--- a/git-hooks/no-commit-to-default-branch
+++ b/git-hooks/no-commit-to-default-branch
@@ -1,8 +1,14 @@
 #! /usr/bin/env bash
 # source https://github.com/bettermarks/.github/git-hooks/
-echo "executing $0 in $(pwd)"
+echo "executing $0 in $PWD"
 set -eu
-current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ $(ls -A1 .git/refs/heads | wc -w) -eq 0 ]; then
+  echo "there is no local branch, so there is no need to prevent any commit"
+  exit 0
+fi
+
+current_branch=$(git branch --show-current)
 
 # needs to be passed as the first argument, should be "main" or "master" in most cases
 default_branch=$1


### PR DESCRIPTION
After some research it seems to be the status quo to configure all hooks inside the repository, instead of on the user level.
This has the advantage of knowing exactly what the default branch is, It is also easier for everybody to be aligned with the hooks and contribute to them.

There are two main options: `husky` for npm-based projects and `pre-commit` for everything else. So I documented both options.

- https://github.com/bettermarks/bm-backend/pull/3040
  to land the backend PR, this PR has to land first, so the rev can be on main and the autoupdate can be enabled
- https://github.com/bettermarks/bm-mifro/pull/3016
- once this PR lands other repos like bm-glu and bm-deployment can follow along
 
 https://bettermarks.slack.com/archives/C49J9TTV4/p1713189295340749